### PR TITLE
dot: Add to_dot function to the Diagram interface

### DIFF
--- a/lib/bdd.ml
+++ b/lib/bdd.ml
@@ -48,6 +48,7 @@ module Make(V:HashCmp) = struct
 
   let equal = B.equal
   let to_string = B.to_string
+  let to_dot = B.to_dot
 
   let var v = atom (v, true) true false
   let neg t = map_r (fun r -> not r) t

--- a/lib/s.mli
+++ b/lib/s.mli
@@ -190,4 +190,9 @@ module type Diagram = sig
 
   val to_string : t -> string
   (** [to_string t] returns a string representation of the diagram. *)
+
+  val to_dot : t -> string
+  (** [to_dot t] returns a string representation of the diagram using the DOT
+      graph description language. The result of this function can be rendered
+      using Graphviz or any other program that supports the DOT language. *)
 end


### PR DESCRIPTION
`to_dot` returns a string that contains a representation of the diagram in the DOT graph description language. Use Graphviz or a similar program to render and view it.
