### PR TITLE
fall through optimization

### DIFF
--- a/lib/s.mli
+++ b/lib/s.mli
@@ -165,6 +165,9 @@ module type Diagram = sig
       applications of [f] to the values that they hold, and branches on
       variables with applications of [g]. *)
 
+  (* SJS: quick and dirty -- this shouldn't be in here *)
+  val to_table : t -> (v list * r) list
+
   val equal : t -> t -> bool
   (** [equal a b] returns whether or not the two diagrams are structurally
       equal.

--- a/lib/vlr.ml
+++ b/lib/vlr.ml
@@ -131,28 +131,24 @@ module Make(V:HashCmp)(L:Lattice)(R:Result) = struct
 
   (* SJS: quick and dirty -- this shouldn't be in here *)
   let to_table t =
-    let rec to_table t tbl pattern =
+    let rec next_table_row t tbl pattern =
       match T.unget t with
       | Leaf r -> (None, (pattern, r) :: tbl)
       | Branch (v, l, t, f) ->
-        let (t_rest, tbl) = to_table t tbl ((v,l) :: pattern) in
+        let (t_rest, tbl) = next_table_row t tbl ((v,l) :: pattern) in
         begin match t_rest with
         | None -> (Some f, tbl)
-        | Some t' ->
-          if equal t' f then
-            (Some t', tbl)
-          else
-            to_table (mk_branch v l t' f) tbl pattern
+        | Some t' -> (Some (mk_branch v l t' f), tbl)
         end
     in
-    let rec finish_rest rest tbl =
-      match to_table rest tbl [] with
+    let rec to_table t tbl =
+      match next_table_row t tbl [] with
       | None, tbl -> List.rev tbl
-      | Some rest, tbl -> finish_rest rest tbl
+      | Some rest, tbl -> to_table rest tbl
     in
-    match to_table t [] [] with
+    match next_table_row t [] [] with
     | None, tbl -> List.rev tbl
-    | Some rest, tbl -> finish_rest rest tbl
+    | Some rest, tbl -> to_table rest tbl
 
 
   let node_min t1 t2 = match (t1, t2) with


### PR DESCRIPTION
This pull request together with https://github.com/frenetic-lang/frenetic/commit/fe53386e59f18c49ed0efb7d1f4d0b84785f98b7 implements fall through optimization. Here are two example to see the effect: https://github.com/frenetic-lang/frenetic/commit/ca3132e25b6f5daf4e466136cd02ad598896b159. The second example is not handled by my first (linear time) implementation; the second (quadratic time) implementation can handle it.
I had to fork and submit a pull request since I don't have the necessary permissions to push directly.